### PR TITLE
IP-241 - Use ruff to enforce import ordering.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # Black code formatting of entire repository
 da4cd7af618fea30ab54052f6ccaa137c5471d82
+
+# ruff import ordering for entire repository
+78e1c643990cbe21c584ac3374e79d2139ae2277

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v0.3.4
     hooks:
       - id: ruff
-        args: ["--fix", "--show-fixes"]
+        args: ["--fix", "--show-fixes", "--select", "I"]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.3.0
     hooks:

--- a/bin/project_local_granule.py
+++ b/bin/project_local_granule.py
@@ -71,8 +71,8 @@
 from os import environ
 from unittest.mock import patch
 
-from harmony.util import config
 from harmony.message import Message
+from harmony.util import config
 
 from swath_projector.adapter import SwathProjectorAdapter
 

--- a/swath_projector/adapter.py
+++ b/swath_projector/adapter.py
@@ -7,7 +7,7 @@ from tempfile import mkdtemp
 
 from harmony import BaseHarmonyAdapter
 from harmony.message import Source as HarmonySource
-from harmony.util import download, generate_output_filename, HarmonyException, stage
+from harmony.util import HarmonyException, download, generate_output_filename, stage
 from pystac import Asset, Item
 
 from swath_projector.reproject import reproject

--- a/swath_projector/interpolation.py
+++ b/swath_projector/interpolation.py
@@ -3,11 +3,12 @@
 
 """
 
+import os
 from functools import partial
 from logging import Logger
 from typing import Dict, List, Optional, Tuple
-import os
 
+import numpy as np
 from netCDF4 import Dataset
 from pyresample.bilinear import get_bil_info, get_sample_from_bil_info
 from pyresample.ewa import fornav, ll2cr
@@ -15,7 +16,6 @@ from pyresample.geometry import AreaDefinition, SwathDefinition
 from pyresample.kd_tree import get_neighbour_info, get_sample_from_neighbour_info
 from pyresample.utils import check_and_wrap
 from varinfo import VarInfoFromNetCDF4
-import numpy as np
 
 from swath_projector.nc_single_band import HARMONY_TARGET, write_single_band_output
 from swath_projector.swath_geometry import (

--- a/swath_projector/nc_merge.py
+++ b/swath_projector/nc_merge.py
@@ -3,15 +3,15 @@
     attributes.
 """
 
-from datetime import datetime, timezone
-from typing import Dict, Optional, Set, Tuple, Union
 import json
 import logging
 import os
+from datetime import datetime, timezone
+from typing import Dict, Optional, Set, Tuple, Union
 
+import numpy as np
 from netCDF4 import Dataset, Variable
 from varinfo import VarInfoFromNetCDF4
-import numpy as np
 
 from swath_projector.exceptions import MissingReprojectedDataError
 from swath_projector.utilities import get_variable_file_path, variable_in_dataset

--- a/swath_projector/nc_single_band.py
+++ b/swath_projector/nc_single_band.py
@@ -25,10 +25,9 @@
 
 from typing import Dict, Tuple
 
-from pyresample.geometry import AreaDefinition
-from netCDF4 import Dataset
 import numpy as np
-
+from netCDF4 import Dataset
+from pyresample.geometry import AreaDefinition
 
 DIMENSION_METADATA = {
     'lat': {

--- a/swath_projector/reproject.py
+++ b/swath_projector/reproject.py
@@ -1,10 +1,10 @@
 """ Data Services Swath Projector service for Harmony """
 
-from tempfile import mkdtemp
-from typing import Dict
 import functools
 import logging
 import os
+from tempfile import mkdtemp
+from typing import Dict
 
 from harmony.message import Message
 from pyproj import Proj
@@ -12,7 +12,6 @@ from varinfo import VarInfoFromNetCDF4
 
 from swath_projector import nc_merge
 from swath_projector.interpolation import resample_all_variables
-
 
 RADIUS_EARTH_METRES = (
     6_378_137  # http://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html

--- a/swath_projector/swath_geometry.py
+++ b/swath_projector/swath_geometry.py
@@ -4,12 +4,12 @@
 
 """
 
-from typing import List, Tuple
 import functools
+from typing import List, Tuple
 
+import numpy as np
 from netCDF4 import Variable
 from pyproj import Proj
-import numpy as np
 
 
 def get_projected_resolution(

--- a/swath_projector/utilities.py
+++ b/swath_projector/utilities.py
@@ -1,9 +1,9 @@
-from typing import Dict, Optional, Tuple, Union
 import os
+from typing import Dict, Optional, Tuple, Union
 
+import numpy as np
 from netCDF4 import Dataset, Variable
 from varinfo import VariableFromNetCDF4
-import numpy as np
 
 from swath_projector.exceptions import MissingCoordinatesError
 

--- a/tests/test_pyresample_reproject.py
+++ b/tests/test_pyresample_reproject.py
@@ -1,11 +1,11 @@
 from unittest import TestCase
-from unittest.mock import patch, ANY
+from unittest.mock import ANY, patch
 
 from harmony.message import Message
 from harmony.util import config
 
 from swath_projector.adapter import SwathProjectorAdapter
-from tests.test_utils import download_side_effect, StringContains
+from tests.test_utils import StringContains, download_side_effect
 
 
 @patch('swath_projector.adapter.stage', return_value='https://example.com/data')

--- a/tests/test_swath_projector.py
+++ b/tests/test_swath_projector.py
@@ -1,17 +1,16 @@
+import json
 from datetime import datetime
 from os import makedirs
 from shutil import copy, rmtree
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
-import json
-
-from netCDF4 import Dataset
+from unittest.mock import ANY, Mock, patch
 
 from harmony.message import Message
 from harmony.util import config
+from netCDF4 import Dataset
 
 from swath_projector.adapter import SwathProjectorAdapter
-from tests.test_utils import download_side_effect, StringContains
+from tests.test_utils import StringContains, download_side_effect
 
 
 @patch('swath_projector.nc_merge.datetime')

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -2,22 +2,22 @@ from logging import Logger
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 from netCDF4 import Dataset
 from pyproj import Proj
 from pyresample.geometry import AreaDefinition
-import numpy as np
 from varinfo import VarInfoFromNetCDF4
 
 from swath_projector.interpolation import (
-    check_for_valid_interpolation,
     EPSILON,
+    RADIUS_OF_INFLUENCE,
+    check_for_valid_interpolation,
     get_parameters_tuple,
     get_reprojection_cache,
     get_swath_definition,
     get_target_area,
     resample_all_variables,
     resample_variable,
-    RADIUS_OF_INFLUENCE,
 )
 from swath_projector.nc_single_band import HARMONY_TARGET
 from swath_projector.reproject import CF_CONFIG_FILE

--- a/tests/unit/test_nc_merge.py
+++ b/tests/unit/test_nc_merge.py
@@ -1,9 +1,9 @@
-from datetime import datetime
-from unittest import TestCase
-from unittest.mock import Mock, patch
 import json
 import logging
 import os
+from datetime import datetime
+from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from netCDF4 import Dataset
 from varinfo import VarInfoFromNetCDF4

--- a/tests/unit/test_nc_single_band.py
+++ b/tests/unit/test_nc_single_band.py
@@ -3,18 +3,18 @@ from tempfile import mkdtemp
 from unittest import TestCase
 from unittest.mock import Mock
 
+import numpy as np
 from netCDF4 import Dataset
 from pyproj.crs import CRS
 from pyresample.geometry import AreaDefinition
-import numpy as np
 
 from swath_projector.nc_single_band import (
-    write_dimensions,
+    HARMONY_TARGET,
     write_dimension_variables,
+    write_dimensions,
     write_grid_mapping,
     write_science_variable,
     write_single_band_output,
-    HARMONY_TARGET,
 )
 
 

--- a/tests/unit/test_swath_geometry.py
+++ b/tests/unit/test_swath_geometry.py
@@ -4,9 +4,9 @@ from tempfile import mkdtemp
 from unittest import TestCase
 from uuid import uuid4
 
+import numpy as np
 from netCDF4 import Dataset
 from pyproj import Proj
-import numpy as np
 
 from swath_projector.swath_geometry import (
     clockwise_point_sort,

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -1,19 +1,19 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
+import numpy as np
 from netCDF4 import Dataset, Variable
 from varinfo import VarInfoFromNetCDF4
-import numpy as np
 
 from swath_projector.exceptions import MissingCoordinatesError
 from swath_projector.utilities import (
     construct_absolute_path,
     create_coordinates_key,
-    get_variable_values,
     get_coordinate_variable,
     get_scale_and_offset,
     get_variable_file_path,
     get_variable_numeric_fill_value,
+    get_variable_values,
     make_array_two_dimensional,
     qualify_reference,
     variable_in_dataset,


### PR DESCRIPTION
## Description

During DAS-2108 @flamingbear and I noticed that imports aren't ordered in HyBIG ([see PR here](https://github.com/nasa/harmony-browse-image-generator/pull/6)). The Swath Projector doesn't get many PRs, so instead of folding this in during a later PR, I've added it now so we don't forget.

## Jira Issue ID

N/A

## Local Test Steps

N/A

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`docker/service_version.txt` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~