### PR TITLE
Add snyk config

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+language-settings:
+  python: "3.11"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ cd harmony-swath-projector
 
 ### Directory contents:
 
+* .snyk - A file used by the Snyk webhook to ensure the correct version of
+  Python is used when installing the full dependency tree for the Swath
+  Projector. This file should be updated when the version of Python is updated
+  in the service Docker image.
 * bin - A directory containing scripts to build and run Docker images. This
   includes the service and test Docker images.
 * docs - A directory containing documentations, primarily in Jupyter notebooks.


### PR DESCRIPTION
## Description

This PR builds on some work that @flamingbear has done in other repositories to add a `.snyk` file that will ensure Snyk uses the correct version of Python when building an environment to scan the Swath Projector dependency tree. This will avoid false positives in our Snyk scans.

This change does not impact the service and only relates to our CI/CD (so it doesn't need a release or updated notes in the change log).

## Jira Issue ID

N/A

## Local Test Steps

Check the scans pass. After merging check the overview of the Snyk project in the UI to ensure the nightly scan picked up the correct Python version.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`docker/service_version.txt` updated if publishing a release.~~
* [x] Tests added/updated and passing.
* [x] Documentation updated (if needed).