### PR TITLE
IP-244 - Update actions/upload-artifacts to v4 due to v3 deprecation.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,13 +30,13 @@ jobs:
         run: ./bin/run-test
 
       - name: Archive test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test results
           path: test-reports/
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Coverage report
           path: coverage/*


### PR DESCRIPTION
## Description

(Same as for `earthdata-varinfo`)

I received a deprecation notice for one of the actions we use to upload artefacts during our CI/CD runs (coverage reports and JUnit style test results output).

For more information see [here](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/#:~:text=On%20January%2030%2C%202025%2C%20the,improved%20performance%20and%20new%20features.).

I don't think there are any breaking changes as we only use very basic options for the action and use unique names for each artefact we upload.

## Jira Issue ID

N/A

## Local Test Steps

N/A - just check there were artefacts saved to the workflow run for this PR. (See [here](https://github.com/nasa/harmony-swath-projector/actions/runs/12268986861?pr=25) - I'm only seeing one artefact. But I think that's something to do with the Swath Projector specifically. It has some weird logging etc for tests that we should probably rip out at some point to simplify things.)

## PR Acceptance Checklist

All are non-applicable. These changes are internal to our CI/CD workflows and will not require a release of any service code.

* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`docker/service_version.txt` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~